### PR TITLE
Add iOS back buttons

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/gousto/kmm/util/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/gousto/kmm/util/Platform.android.kt
@@ -1,0 +1,3 @@
+package com.gousto.kmm.util
+
+actual val isIOS: Boolean = false

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/navigation/AppRoot.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/navigation/AppRoot.kt
@@ -85,7 +85,7 @@ fun AppRoot() {
             }
 
             composable(Routes.RegisterScreen.route) {
-                RegisterScreenComposable()
+                RegisterScreenComposable(navController)
             }
 
             composable(Routes.ProfileScreen.route) {
@@ -123,6 +123,7 @@ fun AppRoot() {
                             ?.set("selectedCourseJson", json)
                         navController.popBackStack()
                     },
+                    onBack = { navController.popBackStack() }
                 )
             }
 
@@ -131,5 +132,4 @@ fun AppRoot() {
             }
 
         }
-    }
-}
+    }}

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/newRound/NewRoundScreenComposable.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/newRound/NewRoundScreenComposable.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHostState
@@ -39,6 +40,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.ArrowBack
+import com.gousto.kmm.util.isIOS
 import androidx.navigation.NavHostController
 import com.gousto.kmm.navigation.Routes
 import com.gousto.kmm.navigation.navModels.CourseNavModel
@@ -96,6 +99,12 @@ fun NewRoundScreenComposable(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            if (isIOS) {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
             // Título y selección de campo (fijo arriba)
             Text("🏌️ Crear nueva partida", style = MaterialTheme.typography.headlineSmall)
 

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/newRound/courses/SelectCourseScreenComposable.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/newRound/courses/SelectCourseScreenComposable.kt
@@ -10,6 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.filled.ArrowBack
+import com.gousto.kmm.util.isIOS
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,7 +30,8 @@ import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun SelectCourseScreenComposable(
-    onCourseSelected: (CourseNavModel) -> Unit
+    onCourseSelected: (CourseNavModel) -> Unit,
+    onBack: () -> Unit
 ) {
     var selectedCourse by remember { mutableStateOf<CourseNavModel?>(null) }
     var selectedGameType by remember { mutableStateOf<GameModeNavModel?>(null) }
@@ -40,6 +45,12 @@ fun SelectCourseScreenComposable(
             .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        if (isIOS) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
         Text("Seleccionar campo", style = MaterialTheme.typography.headlineSmall)
 
         uiState.courses.forEach { course ->

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/register/RegisterScreenComposable.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/register/RegisterScreenComposable.kt
@@ -14,6 +14,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -23,13 +27,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.gousto.kmm.util.isIOS
 import com.gousto.kmm.presentation.screen.register.events.RegisterScreenUiEvent
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 
 @OptIn(KoinExperimentalAPI::class)
 @Composable
-fun RegisterScreenComposable() {
+fun RegisterScreenComposable(navController: NavHostController) {
     val viewModel: RegisterScreenViewModel = koinViewModel()
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -53,6 +59,12 @@ fun RegisterScreenComposable() {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            if (isIOS) {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
             Text("Registro", style = MaterialTheme.typography.titleLarge)
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/round/RoundScreenComposable.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/presentation/screen/round/RoundScreenComposable.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.filled.ArrowBack
+import com.gousto.kmm.util.isIOS
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -82,6 +84,12 @@ fun RoundScreenComposable(
         Modifier.fillMaxSize().padding(16.dp),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
+        if (isIOS) {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(Modifier.height(8.dp))
+        }
         // Información de la ronda
         Column {
             Text("🏌 Seguimiento de ronda", style = MaterialTheme.typography.headlineSmall)

--- a/composeApp/src/commonMain/kotlin/com/gousto/kmm/util/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/com/gousto/kmm/util/Platform.kt
@@ -1,0 +1,3 @@
+package com.gousto.kmm.util
+
+expect val isIOS: Boolean

--- a/composeApp/src/iosMain/kotlin/com/gousto/kmm/util/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/gousto/kmm/util/Platform.ios.kt
@@ -1,0 +1,3 @@
+package com.gousto.kmm.util
+
+actual val isIOS: Boolean = true


### PR DESCRIPTION
## Summary
- show back button on iOS screens
- support detection of iOS platform

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0c482f608330a4e5b74d3d823aef